### PR TITLE
Update mod_perl2.sls

### DIFF
--- a/apache/files/Debian/conf-available/perl.conf.jinja
+++ b/apache/files/Debian/conf-available/perl.conf.jinja
@@ -1,0 +1,3 @@
+{% for option, value in salt['pillar.get']('apache:mod_perl', {}).items() -%}
+{{ option }} {{ value }}
+{% endfor %}

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -32,6 +32,7 @@
         'mod_wsgi': 'libapache2-mod-wsgi',
         'mod_php5': 'libapache2-mod-php5',
         'mod_perl2': 'libapache2-mod-perl2',
+        'mod_perl_name': 'perl',
         'mod_fcgid': 'libapache2-mod-fcgid',
         'mod_pagespeed_source': 'https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_amd64.deb',
         'mod_xsendfile': 'libapache2-mod-xsendfile',

--- a/apache/mod_perl2.sls
+++ b/apache/mod_perl2.sls
@@ -11,12 +11,22 @@ mod-perl2:
       - pkg: apache
 
 {% if grains['os_family']=="Debian" %}
-a2enmod perl2:
+a2enmod {{ apache.mod_perl_name }}:
   cmd.run:
-    - unless: ls /etc/apache2/mods-enabled/perl2.load
+    - unless: ls /etc/apache2/mods-enabled/{{ apache.mod_perl_name }}.load
     - order: 225
     - require:
       - pkg: mod-perl2
+    - watch_in:
+      - module: apache-restart
+
+{{ apache.modulesdir }}/{{ apache.mod_perl_name }}.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/conf-available/perl.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
     - watch_in:
       - module: apache-restart
 


### PR DESCRIPTION
Based on Ubuntu 18.04 perl2.load doesn't exists. See https://packages.ubuntu.com/bionic/amd64/libapache2-mod-perl2/filelist


